### PR TITLE
Feature (front): Endgame Modal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.2.9 // indirect
 	github.com/pkg/profile v1.3.0
+	go.etcd.io/bbolt v1.3.3
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
+go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -27,7 +27,8 @@
 import GomokuHome from "./components/GomokuHome.vue";
 import GameContainer from "./components/gameContainer/GameContainer.vue";
 import SettingsModal from "./components/SettingsModal.vue";
-import { TAB, NOT_STARTED, CONCLUDED, RUNNING } from "./constants";
+import EndGameModal from "./components/EndGameModal.vue";
+import { TAB } from "./constants";
 import axios from "axios";
 import { cloneDeep, merge } from "lodash";
 
@@ -76,12 +77,14 @@ const initialAppState = {
     winner: 0
   },
   winner: 0,
+  showEndGameModal: false,
   showModal: false
 };
 
 export default {
   name: "app",
   components: {
+    EndGameModal,
     GomokuHome,
     GameContainer,
     SettingsModal
@@ -190,10 +193,20 @@ export default {
       const player = this.playerById(playerId);
       if (player) player.AiStatus = !player.AiStatus | 0;
     },
-    closeModal() {
-      this._data.showModal = false;
-      if (this.gameStatus === RUNNING || this.gameStatus === CONCLUDED) this.restartGame(true);
-      else if (this.gameStatus === NOT_STARTED) this.startGame(true);
+    closeModal(modalComponentName = "SettingsModal") {
+      switch (modalComponentName) {
+        case "SettingsModal":
+          this._data.showModal = false;
+          if (this.gameStatus === 1 || this.gameStatus === 2 || this.gameStatus === 3) this.restartGame(true);
+          else if (this.gameStatus === 0) this.startGame(true);
+          break;
+        case "EndGameModal":
+          this._data.showEndGameModal = false;
+          break;
+        default:
+          console.warn(`No modal component with name ${modalComponentName} exists to close.`)
+          break;
+      }
     }
   }
 };

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,6 +7,10 @@
       :playerInfo="playerInfo"
       :showModal="showModal"
     />
+    <EndGameModal
+      v-if="showEndGameModal"
+      :showModal="showEndGameModal"
+    />
     <GameContainer
       v-bind:currentPlayer="currentPlayer"
       v-bind:gameStatus="gameStatus"
@@ -126,6 +130,7 @@ export default {
         this._data.suggestionTimer = res.SuggestionTimer;
         this._data.winner = res.Winner;
         if (res.Winner != 0) {
+<<<<<<< HEAD
           alert("Winner: Player " + res.Winner);
           const postgameInfo = {
             inPostgame: true,
@@ -137,6 +142,11 @@ export default {
           merge(this.$data, initialAppState);
           this._data.gameStatus = CONCLUDED;
           this._data.postgameInfo = postgameInfo;
+=======
+          // alert("Winner: Player " + res.Winner);
+          const showEndGameModal = true;
+          Object.assign(this.$data, initialAppState, { showEndGameModal });
+>>>>>>> modal ctrl flow
         } else if (res.CurrentPlayer.AiStatus === 1) {
           await sleep(100);
           this.makeMove(res.SuggestedPosition, res.CurrentPlayer.Id);

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -10,6 +10,7 @@
     <EndGameModal
       v-if="showEndGameModal"
       :showModal="showEndGameModal"
+      :winner="winner"
     />
     <GameContainer
       v-bind:currentPlayer="currentPlayer"
@@ -145,6 +146,7 @@ export default {
 =======
           // alert("Winner: Player " + res.Winner);
           const showEndGameModal = true;
+          // todo: save winner in postgame, send to modal
           Object.assign(this.$data, initialAppState, { showEndGameModal });
 >>>>>>> modal ctrl flow
         } else if (res.CurrentPlayer.AiStatus === 1) {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -130,7 +130,7 @@ export default {
         this._data.suggestedPosition = res.SuggestedPosition;
         this._data.suggestionTimer = res.SuggestionTimer;
         this._data.winner = res.Winner;
-        if (res.Winner != 0) {
+        if (res.Winner === 1 || res.Winner === 2) {
           const postgameInfo = {
             inPostgame: true,
             tab: cloneDeep(this.tab),
@@ -139,9 +139,6 @@ export default {
             winner: this.winner
           };
           merge(this.$data, initialAppState);
-
-          // todo: save winner in postgame, send to modal
-          // Object.assign(this.$data, initialAppState, { showEndGameModal });
           this._data.gameStatus = CONCLUDED;
           this._data.postgameInfo = postgameInfo;
           this._data.showEndGameModal = true;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -10,7 +10,7 @@
     <EndGameModal
       v-if="showEndGameModal"
       :showModal="showEndGameModal"
-      :winner="winner"
+      :winner="postgameInfo.winner"
     />
     <GameContainer
       v-bind:currentPlayer="currentPlayer"
@@ -33,7 +33,7 @@ import GomokuHome from "./components/GomokuHome.vue";
 import GameContainer from "./components/gameContainer/GameContainer.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import EndGameModal from "./components/EndGameModal.vue";
-import { TAB } from "./constants";
+import { TAB, NOT_STARTED, RUNNING, CONCLUDED } from "./constants";
 import axios from "axios";
 import { cloneDeep, merge } from "lodash";
 
@@ -131,8 +131,6 @@ export default {
         this._data.suggestionTimer = res.SuggestionTimer;
         this._data.winner = res.Winner;
         if (res.Winner != 0) {
-<<<<<<< HEAD
-          alert("Winner: Player " + res.Winner);
           const postgameInfo = {
             inPostgame: true,
             tab: cloneDeep(this.tab),
@@ -141,14 +139,12 @@ export default {
             winner: this.winner
           };
           merge(this.$data, initialAppState);
+
+          // todo: save winner in postgame, send to modal
+          // Object.assign(this.$data, initialAppState, { showEndGameModal });
           this._data.gameStatus = CONCLUDED;
           this._data.postgameInfo = postgameInfo;
-=======
-          // alert("Winner: Player " + res.Winner);
-          const showEndGameModal = true;
-          // todo: save winner in postgame, send to modal
-          Object.assign(this.$data, initialAppState, { showEndGameModal });
->>>>>>> modal ctrl flow
+          this._data.showEndGameModal = true;
         } else if (res.CurrentPlayer.AiStatus === 1) {
           await sleep(100);
           this.makeMove(res.SuggestedPosition, res.CurrentPlayer.Id);

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -209,7 +209,6 @@ export default {
           this._data.showEndGameModal = false;
           break;
         default:
-          console.warn(`No modal component with name ${modalComponentName} exists to close.`)
           break;
       }
     }

--- a/ui/src/components/EndGameModal.vue
+++ b/ui/src/components/EndGameModal.vue
@@ -1,0 +1,139 @@
+<template>
+  <!-- https://vuejs.org/v2/examples/modal.html -->
+  <transition>
+    <div class="modal-mask">
+      <div class="modal-wrapper">
+        <div class="modal-container">
+          <div class="modal-header">
+            <h3>lorem ipsum</h3>
+          </div>
+
+          <div class="modal-body">
+            <p>Some info</p>
+          </div>
+
+          <div class="modal-footer">
+            <button class="modal-default-button" @click="onClose()">OK</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+
+export default {
+  name: "EndGameModal",
+  props: {
+    showModal: {
+			type: Boolean,
+			required: true
+		},
+  },
+  methods: {
+    onClose() {
+      this.$parent.closeModal("EndGameModal");
+    },
+  }
+};
+</script>
+
+<style scoped>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: table;
+  transition: opacity 0.3s ease;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  width: 300px;
+  margin: 0px auto;
+  padding: 20px 30px;
+  background-color: #1c1d21;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
+  transition: all 0.3s ease;
+}
+
+.modal-header h3 {
+  margin-top: 0;
+  color: #ece2d0;
+}
+
+.modal-body {
+  margin: 20px 0;
+  color: #bbb;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+
+.modal-default-button {
+  float: right;
+  font-family: "Share Tech Mono", monospace;
+}
+
+.modal-footer {
+  padding-bottom: 28px;
+}
+
+/* button: same as StartButton.vue */
+button {
+  padding: 9px 12px 9px;
+  background-color: #3cadad;
+  border: none;
+  font-size: 16px;
+  font-weight: bolder;
+  letter-spacing: normal;
+  border-radius: 3px;
+}
+button:hover {
+  background-color: #48cece;
+  cursor: pointer;
+}
+button:active {
+  background-color: #2b7c7c;
+}
+
+.gameOptions {
+  text-align: right;
+}
+
+.gameOptions label {
+  margin-left: 3px;
+}
+
+/*
+ * The following styles are auto-applied to elements with
+ * transition="modal" when their visibility is toggled
+ * by Vue.js.
+ *
+ * You can easily play with the modal transition by editing
+ * these styles.
+ */
+
+.modal-enter {
+  opacity: 0;
+}
+
+.modal-leave-active {
+  opacity: 0;
+}
+
+.modal-enter .modal-container,
+.modal-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/ui/src/components/EndGameModal.vue
+++ b/ui/src/components/EndGameModal.vue
@@ -5,11 +5,7 @@
       <div class="modal-wrapper">
         <div class="modal-container">
           <div class="modal-header">
-            <h3>lorem ipsum</h3>
-          </div>
-
-          <div class="modal-body">
-            <p>Some info</p>
+            <h3>Player {{ winner }} wins!</h3>
           </div>
 
           <div class="modal-footer">
@@ -30,7 +26,13 @@ export default {
 			type: Boolean,
 			required: true
 		},
-  },
+		winner: {
+			required: true,
+			validator(w) {
+				return w === 1 || w === 2
+			}
+		}
+	},
   methods: {
     onClose() {
       this.$parent.closeModal("EndGameModal");

--- a/ui/src/components/SettingsModal.vue
+++ b/ui/src/components/SettingsModal.vue
@@ -53,7 +53,7 @@ export default {
   },
   methods: {
     onClose() {
-      this.$parent.closeModal();
+      this.$parent.closeModal("SettingsModal");
     },
     onToggleSuggestor() {
       this.$parent.toggleSuggestor();


### PR DESCRIPTION
- Removes JS `Window.alert()` on win
- Fix: winner condition in front: `> 0` to `1 || 2` (to account for possible -1 state)
- Alert is replaced with a pretty modal

To test:

Run game, observe modal. Or simply change winner to 1 or 2 at the appropriate point in `updateTab()` method