### PR TITLE
Fix: Add Timer even when suggestor not on

### DIFF
--- a/ui/src/components/gameContainer/scoreBoard/ControlPanel.vue
+++ b/ui/src/components/gameContainer/scoreBoard/ControlPanel.vue
@@ -31,7 +31,6 @@
     </div>
 
     <Timer
-      v-if="suggestorOn"
       v-bind:turn="turn"
       v-bind:suggestionTimer="suggestionTimer"
     />

--- a/ui/src/components/gameContainer/scoreBoard/Timer.vue
+++ b/ui/src/components/gameContainer/scoreBoard/Timer.vue
@@ -2,7 +2,7 @@
   <div id="timer">
     <!-- <div v-if="suggestedPosition && !msElapsedServer"... -->
     <!-- <div v-if-else="msElapsedServer"...> -->
-    <div id="time-up">Suggestion computed in</div>
+    <div id="time-up">Move computed in</div>
     <div>{{ suggestionTimer }} ms</div>
   </div>
 </template>


### PR DESCRIPTION
Add timer to user interface even when suggestor is not explicitly turned on, because it's useful and interesting.

Closed #87